### PR TITLE
Random only checking three of the 13 possible overlap neighbors fixed

### DIFF
--- a/src/main.hpp
+++ b/src/main.hpp
@@ -11,6 +11,7 @@
 #include <algorithm>        /* std::remove */
 #include <iomanip>          /* std::setw() */
 #include <sys/stat.h>       /* chmod */
+#include <utility>          /* std::pair */
 
 
 typedef std::chrono::time_point<std::chrono::high_resolution_clock> time_point;

--- a/src/main.hpp
+++ b/src/main.hpp
@@ -11,7 +11,6 @@
 #include <algorithm>        /* std::remove */
 #include <iomanip>          /* std::setw() */
 #include <sys/stat.h>       /* chmod */
-#include <utility>          /* std::pair */
 
 
 typedef std::chrono::time_point<std::chrono::high_resolution_clock> time_point;

--- a/src/md.hpp
+++ b/src/md.hpp
@@ -34,14 +34,12 @@ struct md_var {
   }
 };
 
-struct position {
-  double x;
-  double y;
-  double z;
+struct vec3d {
+  double x, y, z;
   double length = 0.;
 
   /* Constructors */
-  position(double x_ = 0., double y_ = 0., double z_ = 0.)
+  vec3d(double x_ = 0., double y_ = 0., double z_ = 0.)
   {
     x = x_;
     y = y_;
@@ -52,17 +50,55 @@ struct position {
   /* Functions */
   void calcLength();
   void normalize();
-  void printPos();
+
+  /* Operators */
+  vec3d operator+(const vec3d &a) const
+  {
+    return vec3d(x + a.x, y + a.y, z + a.z);
+  }
+  vec3d operator-(const vec3d &a) const
+  {
+    return vec3d(x - a.x, y - a.y, z - a.z);
+  }
+  vec3d operator*(const double &k) const
+  {
+    return vec3d(k * x, k * y, k * z);
+  }
+  double operator*(const vec3d &a) const
+  {
+    return a.x * x + a.y * y + a.z * z;
+  }
+  vec3d operator*=(const double &k)
+  {
+    x *= k;
+    y *= k;
+    z *= k;
+    return *this;
+  }
+  vec3d operator/(const double &k)
+  {
+    return vec3d(x / k, y / k, z / k);
+  }
+  vec3d operator/=(const double &k)
+  {
+    x /= k;
+    y /= k;
+    z /= k;
+    return *this;
+  }
 };
+vec3d operator*(const double &k, const vec3d &a);
+std::ostream& operator<<(std::ostream &os, const vec3d &a);
+
 
 struct cubeGrid {
   double length;    // length of cube side
   int numPoints;    // points per side, total #points = numPoints^3
-  std::vector<position> gridPoints;
+  std::vector<vec3d> gridPoints;
 
 
   /* Constructors */
-  cubeGrid(double length_, int numPoints_)
+  cubeGrid(double length_ = 100, int numPoints_ = 1)
   {
     length = length_;
     numPoints = numPoints_;
@@ -74,7 +110,7 @@ struct cubeGrid {
         y = j * shift - length / 2.0;
         for (int k = 1; k <= numPoints; k++) {
           z = k * shift - length / 2.0;
-          position pos{x, y, z};
+          vec3d pos(x, y, z);
           gridPoints.push_back(pos);
         }
       }
@@ -86,18 +122,15 @@ struct cubeGrid {
 
 
 /* Functions */
-double dot(position a, position b);
-position normal(position a, position b);
-position getCapsuleA(position centerPoint, double length, double phi,
-                          double theta);
-position getCapsuleB(position centerPoint, double length, double phi,
-                          double theta);
-position closestPtOnLineSegment(position a, position b, position p);
-bool capsuleOverlap(int a, int b, collagenFibril fib,
-                  std::vector<position> &gridPoints,
+vec3d crossproduct(vec3d a, vec3d b);
+vec3d getLinePtA(vec3d centerPoint, double length, double phi, double theta);
+vec3d getLinePtB(vec3d centerPoint, double length, double phi, double theta);
+double shortestDistBetweenLines(vec3d a1, vec3d a2, vec3d b1, vec3d b2);
+bool moleculesOverlap(int a, int b, collagenFibril fib,
+                  std::vector<vec3d> &gridPoints,
                   std::vector<double> &phi_mem,
                   std::vector<double> &theta_mem);
-bool checkOverlap(int i, int L, std::vector<position> &gridPoints,
+bool checkOverlap(int i, int L, std::vector<vec3d> &gridPoints,
                   std::vector<double> &phi_mem,
                   std::vector<double> &theta_mem,
                   collagenFibril fib);

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -2,8 +2,10 @@
 
 
 /* Variables */
+// int seed = 1337;
 std::random_device device;
 std::mt19937 generator(device());
+// std::mt19937 generator(seed);
 
 
 /* Functions */


### PR DESCRIPTION
LAMMPS simulations were not running as expected and the reason was that molecules were still overlapping when placed randomly. This was caused by the algorithm only checking the bottom, left, and behind neighbor for overlap when placing a new molecule on the grid. Now the algorithm checks the nine neighbors in the layer behind the newly placed molecule, the three neighbors to the left and the one neighbor to the bottom of itself. Furthermore, the safety margin was increased to one atom diameter, meaning that a newly placed molecule needs to have a minimum distance of one atom diameter to all neighboring molecules. In principle, safety margin is not necessary, as molecules should be allowed to touch, however, to avoid ill placements with respect to LAMMPS, I decided to enforce a minimum distance between molecules.