### PR TITLE
added feat to output xyz file of minimized struct

### DIFF
--- a/config/default.config
+++ b/config/default.config
@@ -25,6 +25,7 @@ collagen {
 		### Layer-Model ###
 		minimizeEnergy ?= "false";
 		layers ?= "2";
+		xyz_output ?= "false";
 		cd ?= "10";
 		cdcutoff ?= "2.0";
 		lj ?= "0.0";		# set to 0 to deactivate hydrophobic interactions

--- a/src/layermodel.cpp
+++ b/src/layermodel.cpp
@@ -565,6 +565,16 @@ void layerModel::minimizeEnergy()
       }
     }
   }
+
+  if (parameters.xyz_outputs) {
+    std::string xyzfile = filePaths.outputpath;
+    xyzfile += "-"
+      + replace_char(clean_to_string(parameters.lj),'.','_')
+      + "-"
+      +  replace_char(clean_to_string(parameters.cd),'.','_')
+      + ".xyz";
+      output_xyz(xyzfile, 3, latGap, radGap, offset);
+  }
 }
 
 void layerModel::writeXYZ()

--- a/src/parse_config.cpp
+++ b/src/parse_config.cpp
@@ -107,6 +107,7 @@ int parse(int argc, char const *argv[], collagenMolecule &mol, layerModel &lm)
     /* main */
     flags.minimize = cfg->lookupBoolean(scope, "main.minimizeEnergy", false);
     lm.layers = cfg->lookupInt(scope, "main.layers", 2);
+    lm.parameters.xyz_outputs = cfg->lookupBoolean(scope, "main.xyz_output", dummyLm.parameters.xyz_outputs);
     lm.parameters.cd = cfg->lookupFloat(scope, "main.cd", dummyLm.parameters.cd);
     lm.parameters.cd_cutoff = cfg->lookupFloat(scope, "main.cdcutoff", dummyLm.parameters.cd_cutoff);
     lm.parameters.lj = cfg->lookupFloat(scope, "main.lj", dummyLm.parameters.lj);


### PR DESCRIPTION
There is now a new option under main to turn on xyz output, however, this will only be produced after minimising the layer configuration.
So this is what happens:
First, the layer configuration is minimised as usual and after that, for the minimising parameters, your xyz output is generated. If that is not what you wanted, please let me know so I can change it.
If everything is working as you need it, feel free to merge into main.